### PR TITLE
Set resource request and limit

### DIFF
--- a/infra/nyckml-helm/templates/deployment.yaml
+++ b/infra/nyckml-helm/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.frontend.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/infra/nyckml-helm/values.yaml
+++ b/infra/nyckml-helm/values.yaml
@@ -13,6 +13,13 @@ frontend:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest
+  resources:
+    limits:
+      cpu: 256m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
 
 # This is to override the chart name.
 nameOverride: ""
@@ -24,18 +31,6 @@ podAnnotations: {}
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 # livenessProbe:


### PR DESCRIPTION
Given current resource utilization, request is more than enough for many concurrent users. Limits to be safe.
Also move resources under `frontend` as the backend in k8s may be a future thing.

Docs: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/