### PR TITLE
Add back probes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.2-apache-bookworm
 
 COPY ./index.php /var/www/html/
+COPY ./status.php /var/www/html/
 COPY ./nyckml.css /var/www/html/
 COPY ./nyckml.js /var/www/html/
 

--- a/frontend/status.php
+++ b/frontend/status.php
@@ -1,0 +1,1 @@
+<?php echo "We're meshin'." ?>

--- a/infra/nyckml-helm/templates/deployment.yaml
+++ b/infra/nyckml-helm/templates/deployment.yaml
@@ -39,11 +39,11 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.service.port }}
               protocol: TCP
-          {{- with .Values.livenessProbe }}
+          {{- with .Values.frontend.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.readinessProbe }}
+          {{- with .Values.frontend.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/infra/nyckml-helm/values.yaml
+++ b/infra/nyckml-helm/values.yaml
@@ -13,6 +13,14 @@ frontend:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest
+  livenessProbe:
+    httpGet:
+      path: /status.php
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /status.php
+      port: http
 
 # This is to override the chart name.
 nameOverride: ""
@@ -36,16 +44,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-# livenessProbe:
-#   httpGet:
-#     path: /
-#     port: http
-# readinessProbe:
-#   httpGet:
-#     path: /
-#     port: http
 
 nodeSelector: {}
 


### PR DESCRIPTION
Probes were previously disabled due to an issue with undefined vars.

Add them back but for a new very simple `status.php` file.

Docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/